### PR TITLE
[calibration] 키보드 영역 calibration 기능 구현

### DIFF
--- a/piano-ar/calibration/calibrator.py
+++ b/piano-ar/calibration/calibrator.py
@@ -1,0 +1,38 @@
+import cv2
+
+points = []
+
+def mouse(event, x, y, flags, param):
+    if event == cv2.EVENT_LBUTTONDOWN:
+        if len(points) < 4:
+            points.append((x,y))
+            
+def calibrate(cap):
+    global points
+    points = []
+    
+    cv2.namedWindow("Calibration")
+    cv2.setMouseCallback("Calibration", mouse)
+    
+    while True:
+        ret, frame = cap.read()
+        
+        if not ret:
+            print("프레임 읽기 실패")
+            break
+        
+        temp = frame.copy()
+        
+        for p in points:
+            cv2.circle(temp, p, 5, (0,255,0), -1)
+            
+        cv2.imshow("Calibration", temp)
+        
+        if len(points) == 4:
+            break
+        
+        if cv2.waitKey(1) == 27:
+            break
+        
+    cv2.destroyWindow("Calibration")
+    return points

--- a/piano-ar/main.py
+++ b/piano-ar/main.py
@@ -1,19 +1,8 @@
-import cv2
 from camera.capture import open_camera
 
 cap = open_camera()
 
-while True:
-    ret, frame = cap.read()
-    
-    if not ret:
-        print("프레임 읽기 실패")
-        break
-    
-    cv2.imshow('Camera Test', frame)
-    
-    if cv2.waitKey(1) == 27:  # ESC 키를 누르면 종료
-        break
-    
-cap.release()
-cv2.destroyAllWindows()
+from calibration.calibrator import calibrate
+
+points = calibrate(cap)
+print("선택된 좌표:", points)


### PR DESCRIPTION
## 🔎개요

웹캠 화면에서 키보드 영역을 설정하기 위한 캘리브레이션 기능을 구현했습니다.  사용자가 마우스로 4개의 좌표를 클릭하면 해당 좌표를 반환하도록 구성했습니다.

<br/>
 
## 📝작업 내용
- OpenCV 마우스 이벤트를 활용한 좌표 선택 기능 구현
- 클릭한 좌표를 화면에 시각적으로 표시 (초록색 원으로 표시)
- 4개 좌표 선택 시 자동 종료 + 좌표값 출력되도록 처리
- ESC 키 입력 시 캘리브레이션 종료 기능 추가 
 
<br/>
 
## 👀변경 사항
- main.py에 calibrate 함수 호출 로직 추가
- 캘리브레이션 완료 후 반환되는 좌표 리스트를 기반으로 이후 기능(ROI 설정 등)에 활용 가능
- 전역 변수(points)를 사용하고 있어 추후 리팩토링 필요 가능성 있음
 
<br/>
 
## 📸UI 스크린샷
웹캠 화면에서 클릭한 위치에 초록색 원 표시
<img width="859" height="673" alt="image" src="https://github.com/user-attachments/assets/5f5eaf91-8e85-4d15-a8a7-2489cb1d6131" />
4점 클릭 시 자동 종료와 함께 좌표 출력
<img width="558" height="92" alt="image" src="https://github.com/user-attachments/assets/d6917156-6682-4790-9a33-a281494e9eac" />
 
<br/>

## 👉참고

- 추후 사용자에게 어느 순서로 좌표값 선택하라는 프롬프트 출력 필요

<br> 

 
## #️⃣관련 이슈
- close #3
