### PR TITLE
[transform] 키보드 영역 Perspective Transform 적용

### DIFF
--- a/piano-ar/main.py
+++ b/piano-ar/main.py
@@ -1,8 +1,21 @@
+import cv2
+
 from camera.capture import open_camera
+from calibration.calibrator import calibrate
+from utils.transform import get_matrix, warp
 
 cap = open_camera()
-
-from calibration.calibrator import calibrate
-
 points = calibrate(cap)
-print("선택된 좌표:", points)
+matrix = get_matrix(points)
+
+while True:
+    ret, frame = cap.read()
+    if not ret:
+        break
+
+    warped = warp(frame, matrix)
+
+    cv2.imshow("Warped", warped)
+
+    if cv2.waitKey(1) == 27:
+        break

--- a/piano-ar/utils/transform.py
+++ b/piano-ar/utils/transform.py
@@ -1,0 +1,19 @@
+import cv2
+import numpy as np
+
+WIDTH = 800
+HEIGHT = 200
+
+def get_matrix(points):
+    src = np.float32(points)
+    dst = np.float32([
+        [0, 0],
+        [WIDTH, 0],
+        [WIDTH, HEIGHT],
+        [0, HEIGHT]
+    ])
+    
+    return cv2.getPerspectiveTransform(src, dst)
+
+def warp(frame, matrix):
+    return cv2.warpPerspective(frame, matrix, (WIDTH, HEIGHT))


### PR DESCRIPTION
## 🔎개요
캘리브레이션으로 선택한 4개의 좌표를 기반으로  키보드 영역을 정면에서 바라본 직사각형 형태로 변환하는 Perspective Transform 기능을 구현했습니다.


<br/>
 
## 📝작업 내용
- cv2.getPerspectiveTransform을 활용한 변환 행렬 계산 기능 구현
- cv2.warpPerspective를 활용한 영상 변환 기능 구현
- 변환된 키보드 영역을 "Warped" 창으로 출력하도록 구성
 
 
<br/>
 
## 👀변경 사항
- main.py에 Perspective Transform 적용 로직 추가
- 캘리브레이션 결과(points)를 기반으로 변환 행렬(matrix) 생성
- 입력 좌표 순서에 따라 결과가 달라질 수 있어 추후 좌표 정렬 로직 필요
 
<br/>
 
## 📸UI 스크린샷
calibration 4좌표 찍은 후에 나타나는 transform 화면
<img width="642" height="190" alt="image" src="https://github.com/user-attachments/assets/68bb4ffd-fdc0-42aa-b31b-4053323274ed" />
 
<br/>
 
## 📦패키지 설치
- NumPy
  - 좌표 배열 및 행렬 연산 처리
 
 
<br/>
 
## 👉참고
- 자동으로 건반 4좌표 잡는 로직 구현 생각..
  1. 엣지 + 사각형 검출 (가장 기본)
  2. 색 기반 (흰 건반 + 검은 건반 패턴)
  3. Hough Line (직선 기반)
  4. 딥러닝 (YOLO ..?)

- 위에 방법 성공하면 자동 변환 -> 실패 -> 수동 변환으로 변경 필요

## #️⃣관련 이슈
close #5
