### PR TITLE
[ar] 피아노 AR 오버레이 렌더링 구현

### DIFF
--- a/piano-ar/ar/overlay.py
+++ b/piano-ar/ar/overlay.py
@@ -1,0 +1,19 @@
+import cv2
+
+def render(frame, whites, blacks):
+    overlay = frame.copy()
+
+    # 흰 건반 테스트
+    test_white = [10, 11, 12]
+
+    for i in test_white:
+        x1, y1, x2, y2 = whites[i]
+        cv2.rectangle(overlay, (x1, y1), (x2, y2), (0, 255, 0), -1)
+
+    # 검은 건반 테스트
+    test_black = [0, 1, 2]  
+    for i in test_black:
+        x1, y1, x2, y2 = blacks[i]
+        cv2.rectangle(overlay, (x1, y1), (x2, y2), (0, 0, 255), -1)
+
+    return cv2.addWeighted(overlay, 0.4, frame, 0.6, 0)

--- a/piano-ar/main.py
+++ b/piano-ar/main.py
@@ -4,11 +4,15 @@ from camera.capture import open_camera
 from calibration.calibrator import calibrate
 from utils.transform import get_matrix, warp
 from keyboard.mapping import build_keys
+from ar.overlay import render
 
-
+# 카메라 (camera)
 cap = open_camera()
 
+# 캘리브레이션 (calibration)
 points = calibrate(cap)
+
+# 변환 행렬 (transform)
 matrix = get_matrix(points)
 
 while True:
@@ -16,7 +20,10 @@ while True:
     if not ret:
         break
 
+    # 키보드 정면화 (transform)
     warped = warp(frame, matrix)
+    
+    # 키 생성 (keyboard)
     h, w = warped.shape[:2]
     whites, blacks = build_keys(w, h)
 
@@ -29,7 +36,11 @@ while True:
         cv2.rectangle(warped, (x1, y1), (x2, y2), (50, 50, 50), -1)  
         cv2.rectangle(warped, (x1, y1), (x2, y2), (0, 200, 255), 1)  
 
-    cv2.imshow("Warped", warped)
+    # AR 렌더 (ar)
+    output = render(warped, whites, blacks)
+
+    # 출력
+    cv2.imshow("Piano AR", output)
 
     if cv2.waitKey(1) == 27:
         break


### PR DESCRIPTION
## 🔎개요
Perspective Transform 이후 생성된 키보드 좌표를 기반으로 영상 위에 AR 형태로 건반을 시각화하는 오버레이 기능 구현

<br/>
 
## 📝작업 내용

### 1. AR 오버레이 모듈 추가
- frame copy 기반 overlay 레이어 생성
- alpha blending 적용 (cv2.addWeighted)

### 2. 건반 하이라이트 로직
- 흰색, 검은ㅅ댁 좌표 기반 특정 키 영역 선택
- 테스트용으로 하드코딩
  - 흰색 건반 : 초록색으로 채움 (10, 11, 12)
  - 검은색 건반 : 빨간색으로 채움 (0, 1, 2)

### 3. main.py 연결
- warped frame → render() → output 흐름 구성
- "Piano AR" 창에서 결과 확인 가능

<br/>
 
## 👀변경 사항
- 기존 단순 시각화 구조 → AR 오버레이 구조로 확장
- 렌더링 로직이 별도 모듈로 분리됨 (ar layer 추가)
- 화면 합성 방식(alpha blending) 도입
 
 
<br/>
 
## 📸UI 스크린샷
오버레이는 되는데 현재 건반 매핑이 항상 일정하게 맞지는 않는 상태.. (#8 참고)
<img width="681" height="394" alt="image" src="https://github.com/user-attachments/assets/94bb4003-2343-44fd-98a4-2a941ca9d80e" />

 
<br/>
 
 
## 👉참고

- 현재는 테스트용 하드코딩된 키 범위 사용
- 이후 단계에서 실제 입력 감지 결과와 연결 예정
- AR 효과는 투명도 0.4 / 0.6 기준으로 합성 -> 후에 키 렌더링 방식 확정 시 수정 필요
<br/>
 
## #️⃣관련 이슈
- close #9 
